### PR TITLE
[AURA] Call changeRainSounds() on loaded?

### DIFF
--- a/AURA/Misc/rainSounds.lua
+++ b/AURA/Misc/rainSounds.lua
@@ -100,6 +100,7 @@ end
 
 print("[AURA "..version.."] Rain sounds initialised.")
 WtC=tes3.worldController.weatherController
+event.register("loaded", changeRainSounds, {priority=-233})
 event.register("weatherChangedImmediate", changeRainSounds, {priority=-233})
 event.register("weatherTransitionImmediate", changeRainSounds, {priority=-233})
 event.register("weatherTransitionStarted", rainStartCheck, {priority=-233})


### PR DESCRIPTION
Would it be a good idea to call `changeRainSounds()` on eventId `loaded` as well? Because otherwise we're going to be stuck with the vanilla (or replacer) rain sound until one of the other 3 event types fires.

This would be useful when loading a save game where it's already raining (and the player is outside). The script would immediately change the `rainLoopSound` according to the rain type, and avoid a potential inconsistency between particle amount and rain sound being played.