### PR TITLE
[AURA] Prevent overlap with vanilla rainLoopSound

### DIFF
--- a/AURA/Misc/rainSounds.lua
+++ b/AURA/Misc/rainSounds.lua
@@ -69,6 +69,10 @@ local function changeRainSounds()
     debugLog("Rain type: "..rainyType)
     debugLog("Storm type: "..stormyType)
 
+    if WtC.currentWeather.rainLoopSound then
+        WtC.currentWeather.rainLoopSound:stop()
+    end
+
     -- Load sounds --
     rainy.rainLoopSound = tes3.getSound(rainLoops["Rain"][rainyType])
     stormy.rainLoopSound = tes3.getSound(rainLoops["Thunderstorm"][stormyType])


### PR DESCRIPTION
It appears that calling `changeRainSounds()` on loaded adds a `rainLoopSound` on top of the currently running `rainLoopSound`.

Both the vanilla `rainLoopSound` and the one just added by changeRainSounds() will play at the same time. This can be tested by typing `tes3.worldController.weatherController.currentWeather.rainLoopSound:stop()` in the lua console after loading a saved game where it's raining. Vanilla sound will stop and you will be able to hear the `tew_` sound (or viceversa). Note: It resets back to it playing when you close the console, and they will continue to overlap. It sounds unpleasantly loud, too.

Tested and this patch fixes the issue ;)