### PR TITLE
[AURA] Patch for migration to region ids

### DIFF
--- a/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -118,7 +118,7 @@ local function cellCheck()
 		region = regionObject.id
 		weatherNow = regionObject.weather.index
 	else
-		region = tes3.getRegion().name -- Otherwise we can just get the region from the cell --
+		region = tes3.getRegion().id -- Otherwise we can just get the region from the cell --
 		if WtC.nextWeather then
 			weatherNow = WtC.nextWeather.index
 		else


### PR DESCRIPTION
Since we're working with `tes3region` object ids now, let's make that consistent.

On a side note, and I'm not sure about this, shouldn't we switch to ids for cells as well? There are a lot of `cell.name` references in the code.